### PR TITLE
Add an option to compress size

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
+
 pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex &> log.md
 bibtex oq-manual > log.md
 pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex &> log.md

--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,13 @@ makeglossaries oq-manual &> log.md
 pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex &> log.md
 cat log.md | egrep "Error|Warning"
 ./clean.sh
-open oq-manual.pdf
+if [ "$1" == "--compress" ]; then
+    pdfinfo "oq-manual.pdf" | sed -e 's/^ *//;s/ *$//;s/ \{1,\}/ /g' -e 's/^/  \//' -e '/CreationDate/,$d' -e 's/$/)/' -e 's/: / (/' > .pdfmarks
+    sed -i '1s/^ /[/' .pdfmarks
+    sed -i '/:)$/d' .pdfmarks
+    echo "  /DOCINFO pdfmark" >> .pdfmarks
+
+    gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/printer -dNOPAUSE -dQUIET -dBATCH -sOutputFile=compressed-oq-manual.pdf oq-manual.pdf .pdfmarks
+
+    mv -f compressed-oq-manual.pdf oq-manual.pdf
+fi


### PR DESCRIPTION
Had to remove `open` because causes trouble on the automatic builder (https://ci.openquake.org/job/builders/job/manual-builder/). The `--compress` option requires GhostScript and Poppler.

See the builder in action here: https://ci.openquake.org/job/builders/job/manual-builder/4/console
And the artifact (compressed): https://ci.openquake.org/job/builders/job/manual-builder/lastSuccessfulBuild/artifact/oq-engine-docs/oq-manual.pdf

Source of the underlying Docker is here https://github.com/gem/oq-containers/blob/master/jenkins/Dockerfile.manual